### PR TITLE
Feature 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 List of changes between versions
 
+## 0.6.3
+
+Changes
+
+- Bumped version of `ocr_translate_ollama` plugin to `0.2.0` in order to allow using newer versions of `ollama` (> 0.5.5)
+
+
 ## 0.6.2
 
 Changes

--- a/ocr_translate/__init__.py
+++ b/ocr_translate/__init__.py
@@ -18,5 +18,5 @@
 ###################################################################################
 """OCR and translation of images."""
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 __version__array__ = [int(_) for _ in __version__.split('.')]

--- a/ocr_translate/plugins_data.json
+++ b/ocr_translate/plugins_data.json
@@ -1063,7 +1063,7 @@
     "package": "ocr_translate_ollama",
     "description": "This is a plugin for ocr_translate that implements translations through ollama using Large Language Models (LLM)s.",
     "warning": "This plugin requires a running ollama server that is not include with the project. See the homepage for more details",
-    "version": "0.1.4",
+    "version": "0.2.0",
     "homepage": "https://github.com/Crivella/ocr_translate-ollama",
     "dependencies": [
       {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ exclude = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 DJANGO_SETTINGS_MODULE = "mysite.settings"
-log_cli = 1
+log_cli = true
 
 [tool.pylint.main]
 load-plugins = [

--- a/run_server.py
+++ b/run_server.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-req_version = os.environ.get('OCT_VERSION', '0.6.2').lower()
+req_version = os.environ.get('OCT_VERSION', '0.6.3').lower()
 
 def install_upgrade(upgrade=False):
     """Install or upgrade the ocr_translate package."""


### PR DESCRIPTION
- Bumped version of `ocr_translate_ollama` plugin to `0.2.0` in order to allow using newer versions of `ollama` (> 0.5.5)
