### PR TITLE
Respect environment variables

### DIFF
--- a/start-server.sh
+++ b/start-server.sh
@@ -22,14 +22,14 @@ nginx
 
 su ${USER}
 
-export OCT_DJANGO_PORT=4010
-export OCT_BASE_DIR="/plugin_data"
-export TRANSFORMERS_CACHE="/models/huggingface"
-export TRANSFORMERS_OFFLINE="0"
-export EASYOCR_MODULE_PATH="/models/easyocr"
-export TESSERACT_PREFIX="/models/tesseract"
-export TESSERACT_ALLOW_DOWNLOAD="true"
-export PADDLEOCR_PREFIX="/models/paddleocr"
+export OCT_DJANGO_PORT=${OCT_DJANGO_PORT:-4010}
+export OCT_BASE_DIR=${OCT_BASE_DIR:-"/plugin_data"}
+export TRANSFORMERS_CACHE=${TRANSFORMERS_CACHE:-"/models/huggingface"}
+export TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-"0"}
+export EASYOCR_MODULE_PATH=${EASYOCR_MODULE_PATH:-"/models/easyocr"}
+export TESSERACT_PREFIX=${TESSERACT_PREFIX:-"/models/tesseract"}
+export TESSERACT_ALLOW_DOWNLOAD=${TESSERACT_ALLOW_DOWNLOAD:-"true"}
+export PADDLEOCR_PREFIX=${PADDLEOCR_PREFIX:-"/models/paddleocr"}
 
 source /venv/bin/activate
 python run_server.py


### PR DESCRIPTION
Have start-server.sh respect environment variables that have been set by the user. Given that the Docker uses start-server.sh as its entry point, overwriting the users environment variables causes data to be lost when the container is stopped, forcing a re-download of all plugins and models.

I haven't actually tested the Docker container after making these changes though, as I'm not quite sure where `media` and `staticfiles` are supposed to come from, and I didn't see anything about them during a quick look through the docs.