### PR TITLE
Use python variable for creating venv

### DIFF
--- a/release_files/run.sh
+++ b/release_files/run.sh
@@ -35,7 +35,7 @@ start_venv() {
     if [ -x "$VENV_DIR/bin/python" ]; then
         activate_venv
     else
-        PYTHON_FULLNAME=$(python -c "import sys; print(sys.executable)")
+        PYTHON_FULLNAME=$($PYTHON -c "import sys; print(sys.executable)")
         echo "Creating venv in directory $VENV_DIR using python $PYTHON_FULLNAME"
         $PYTHON_FULLNAME -m venv "$VENV_DIR" >tmp/stdout.txt 2>tmp/stderr.txt
         if [ $? -eq 0 ]; then


### PR DESCRIPTION
When running the script on Linux using sh for the first time it could not find python on line 38, which led to unable to run the command on line 40, as seen below:
```
PYTHON=python3 sh ./run-user.sh
./run.sh: line 38: python: command not found
Creating venv in directory ./venv using python 
Unable to create venv in directory ./venv

exit code: 0

stderr:
./run.sh: line 40: -m: command not found
`ocr_translate` not found: installing django-ocr_translate...
Installing ocr_translate 0.7.4...
```

The issue stems from not using the python variable when creating a venv, hence the problem is not present when one is already created.

The minor change to instead use the variable fixed the problem.